### PR TITLE
fix: package.json & .snyk to reduce vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,14 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.7.1
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:minimatch:20160620':
+    - gulp > vinyl-fs > glob-stream > minimatch:
+        patched: '2017-09-29T17:12:44.798Z'
+    - gulp > vinyl-fs > glob-stream > glob > minimatch:
+        patched: '2017-09-29T17:12:44.798Z'
+    - gulp > vinyl-fs > glob-watcher > gaze > globule > minimatch:
+        patched: '2017-09-29T17:12:44.798Z'
+    - gulp > vinyl-fs > glob-watcher > gaze > globule > glob > minimatch:
+        patched: '2017-09-29T17:12:44.798Z'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Common Look and Feel framework for UBC",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "snyk-protect": "snyk protect",
+    "prepare": "npm run snyk-protect"
   },
   "repository": {
     "type": "git",
@@ -26,6 +28,8 @@
     "gulp-cssnano": "^2.1.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0",
-    "gulp-sourcemaps": "^2.6.0"
-  }
+    "gulp-sourcemaps": "^2.6.0",
+    "snyk": "^1.41.1"
+  },
+  "snyk": true
 }


### PR DESCRIPTION
The following vulnerabilities are fixed with a Snyk patch:
- https://snyk.io/vuln/npm:minimatch:20160620

Latest report for occupant/ubc-clf8:
https://snyk.io/test/github/occupant/ubc-clf8